### PR TITLE
Update plugin author to WooCommerce and rename default production from 'master' to 'trunk'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A list of features included in this add-on are [available on the website](https:
 
 To install:
 
-1. Download the latest version of the plugin [here](https://github.com/Prospress/automatewoo-agilecrm/archive/master.zip)
+1. Download the latest version of the plugin [here](https://github.com/woocommerce/automatewoo-agilecrm/releases)
 1. Go to **Plugins > Add New > Upload** administration screen on your WordPress site
 1. Select the ZIP file you just downloaded
 1. Click **Install Now**

--- a/automatewoo-agilecrm.php
+++ b/automatewoo-agilecrm.php
@@ -4,16 +4,18 @@
  * Plugin URI: http://automatewoo.com
  * Description: AgileCRM Integration add-on for AutomateWoo.
  * Version: 1.4.4
- * Author: AutomateWoo
- * Author URI: http://automatewoo.com
+ * Author: WooCommerce
+ * Author URI: https://woocommerce.com/
  * License: GPLv3
  * License URI: http://www.gnu.org/licenses/gpl-3.0
  * Text Domain: automatewoo-agilecrm
- * GitHub Plugin URI: Prospress/automatewoo-agilecrm
+ *
+ * GitHub Plugin URI: woocommerce/automatewoo-agilecrm
+ * Primary Branch: trunk
  */
 
 
-// Copyright (c) 2016 AutomateWoo. All rights reserved.
+// Copyright (c) 2020 WooCommerce. All rights reserved.
 //
 // Released under the GPLv3 license
 // http://www.gnu.org/licenses/gpl-3.0

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,7 +70,7 @@ gulp.task( 'wp-pot', [ 'clean:pot' ], () => {
 			//'bugReport': packageJSON.bugs.url,
 			'domain': packageJSON.name,
 			'package': packageJSON.title,
-			'team': 'Prospress Translations <translations@prospress.com>',
+			'team': '',
 			'writeFile': false,
 			'headers': {
 				'Language': 'en_US',


### PR DESCRIPTION
Part of https://github.com/woocommerce/automatewoo/issues/746

I've added a ["Primary Branch" header for the GitHub updater](https://github.com/afragen/github-updater/wiki/Settings#primary-branch). We will need to ensure 1.4.5 is pushed to `master` since existing sites will be looking there for an update.