### PR TITLE
Fix missing action names and groups

### DIFF
--- a/includes/actions/abstract.php
+++ b/includes/actions/abstract.php
@@ -9,9 +9,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  */
 abstract class Action_AgileCRM_Abstract extends Action {
 
-
-	function init() {
-		$this->group = __( 'AgileCRM', 'automatewoo-agilecrm' );
+	/**
+	 * Get action group.
+	 *
+	 * @return string
+	 */
+	public function get_group() {
+		return __( 'AgileCRM', 'automatewoo-agilecrm' );
 	}
 
 

--- a/includes/actions/add-contact.php
+++ b/includes/actions/add-contact.php
@@ -10,10 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Action_AgileCRM_Add_Contact extends Action_AgileCRM_Abstract {
 
 
-	public function init() {
+	public function load_admin_details() {
 		$this->title = __( 'Create / Update Contact', 'automatewoo-agilecrm' );
 		$this->description = __( 'This trigger can be used to create or update contacts in AgileCRM. If an existing contact is found by email then an update will occur otherwise a new contact will be created. When updating a contact any fields left blank will not be updated e.g. if you only want to update the address just select an address and enter an email, all other fields can be left blank.', 'automatewoo-agilecrm' );
-		parent::init();
 	}
 
 

--- a/includes/actions/add-note.php
+++ b/includes/actions/add-note.php
@@ -10,9 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Action_AgileCRM_Add_Note extends Action_AgileCRM_Abstract {
 
 
-	public function init() {
+	public function load_admin_details() {
 		$this->title = __('Add Note To Contact', 'automatewoo-agilecrm');
-		parent::init();
 	}
 
 

--- a/includes/actions/add-tags.php
+++ b/includes/actions/add-tags.php
@@ -10,9 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Action_AgileCRM_Add_Tags extends Action_AgileCRM_Abstract {
 
 
-	public function init() {
+	public function load_admin_details() {
 		$this->title = __( 'Add Tags To Contact', 'automatewoo-agilecrm' );
-		parent::init();
 	}
 
 

--- a/includes/actions/add-task.php
+++ b/includes/actions/add-task.php
@@ -10,10 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Action_AgileCRM_Add_Task extends Action_AgileCRM_Abstract {
 
 
-	public function init() {
+	public function load_admin_details() {
 		$this->title = __( 'Add Task To Contact', 'automatewoo-agilecrm' );
 		$this->description = __( 'Please note you must first create the contact in AgileCRM before assigning any tasks to them.', 'automatewoo-agilecrm' );
-		parent::init();
 	}
 
 

--- a/includes/actions/create-deal.php
+++ b/includes/actions/create-deal.php
@@ -11,9 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Action_AgileCRM_Create_Deal extends Action_AgileCRM_Abstract {
 
 
-	function init() {
+	function load_admin_details() {
 		$this->title = __('Create Deal', 'automatewoo-agilecrm');
-		parent::init();
 	}
 
 

--- a/includes/actions/remove-tags.php
+++ b/includes/actions/remove-tags.php
@@ -10,9 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Action_AgileCRM_Remove_Tags extends Action_AgileCRM_Abstract {
 
 
-	function init() {
+	function load_admin_details() {
 		$this->title = __( 'Remove Tags From Contact', 'automatewoo-agilecrm');
-		parent::init();
 	}
 
 

--- a/includes/actions/update-contact-field.php
+++ b/includes/actions/update-contact-field.php
@@ -11,9 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class Action_AgileCRM_Update_Contact_Field extends Action_AgileCRM_Abstract {
 
 
-	function init() {
+	function load_admin_details() {
 		$this->title = __( 'Update Contact Custom Field', 'automatewoo-agilecrm' );
-		parent::init();
 	}
 
 


### PR DESCRIPTION
Fixes #3 

It looks to me like the name/group are no longer loading for each action due to changes in AW 5.2 where we deprecated and stopped calling `\AutomateWoo\Action:init()` when each action was registered.